### PR TITLE
Fix incorrect deletion of training in TrainingExercise service

### DIFF
--- a/src/main/java/back/SportApp/TrainingExercise/TrainingExerciseRepository.java
+++ b/src/main/java/back/SportApp/TrainingExercise/TrainingExerciseRepository.java
@@ -26,4 +26,8 @@ public interface TrainingExerciseRepository extends JpaRepository<TrainingExerci
     @Modifying
     @Query("DELETE FROM TrainingExercise te WHERE te.training.id = :trainingId")
     void deleteByTrainingId(@Param("trainingId") Integer trainingId);
+
+    @Modifying
+    @Query("DELETE FROM TrainingExercise te WHERE te.training.id = :trainingId AND te.exercise.id = :exerciseId")
+    void deleteByTrainingIdAndExerciseId(@Param("trainingId") Integer trainingId, @Param("exerciseId") Integer exerciseId);
 }

--- a/src/main/java/back/SportApp/TrainingExercise/TrainingExerciseServiceImpl.java
+++ b/src/main/java/back/SportApp/TrainingExercise/TrainingExerciseServiceImpl.java
@@ -9,6 +9,7 @@ import back.SportApp.User.repository.UserPasswordRepository;
 import back.SportApp.User.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
@@ -38,10 +39,12 @@ public class TrainingExerciseServiceImpl implements TrainingExerciseService {
         trainingExerciseRepository.save(trainingExercise);
     }
 
+    @Transactional
     public void deleteExerciseTraining(Integer trainingId, Integer exerciseId) {
-        Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new RuntimeException("Training not found"));
-        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(() -> new RuntimeException("Exercise not found"));
-        trainingRepository.delete(training);
+        trainingRepository.findById(trainingId).orElseThrow(() -> new RuntimeException("Training not found"));
+        exerciseRepository.findById(exerciseId).orElseThrow(() -> new RuntimeException("Exercise not found"));
+
+        trainingExerciseRepository.deleteByTrainingIdAndExerciseId(trainingId, exerciseId);
     }
 
     public Set<Exercise> getExerciseFromTraining(Integer trainingId) {

--- a/src/test/java/back/SportApp/TrainingExercise/TrainingExerciseServiceImplTest.java
+++ b/src/test/java/back/SportApp/TrainingExercise/TrainingExerciseServiceImplTest.java
@@ -1,0 +1,93 @@
+package back.SportApp.TrainingExercise;
+
+import back.SportApp.Exercise.Exercise;
+import back.SportApp.Exercise.ExerciseRepository;
+import back.SportApp.Training.Training;
+import back.SportApp.Training.TrainingRepository;
+import back.SportApp.User.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TrainingExerciseServiceImplTest {
+
+    @Mock
+    private TrainingExerciseRepository trainingExerciseRepository;
+    @Mock
+    private TrainingRepository trainingRepository;
+    @Mock
+    private ExerciseRepository exerciseRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private TrainingExerciseServiceImpl service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        service = new TrainingExerciseServiceImpl();
+        Field f;
+        f = TrainingExerciseServiceImpl.class.getDeclaredField("trainingExerciseRepository");
+        f.setAccessible(true);
+        f.set(service, trainingExerciseRepository);
+        f = TrainingExerciseServiceImpl.class.getDeclaredField("trainingRepository");
+        f.setAccessible(true);
+        f.set(service, trainingRepository);
+        f = TrainingExerciseServiceImpl.class.getDeclaredField("exerciseRepository");
+        f.setAccessible(true);
+        f.set(service, exerciseRepository);
+        f = TrainingExerciseServiceImpl.class.getDeclaredField("userRepository");
+        f.setAccessible(true);
+        f.set(service, userRepository);
+    }
+
+    @Test
+    void deleteExerciseTraining_success() {
+        Training training = new Training();
+        training.setId(1);
+        Exercise exercise = new Exercise();
+        exercise.setId(2);
+
+        when(trainingRepository.findById(1)).thenReturn(Optional.of(training));
+        when(exerciseRepository.findById(2)).thenReturn(Optional.of(exercise));
+
+        assertDoesNotThrow(() -> service.deleteExerciseTraining(1, 2));
+
+        verify(trainingRepository).findById(1);
+        verify(exerciseRepository).findById(2);
+        verify(trainingExerciseRepository).deleteByTrainingIdAndExerciseId(1, 2);
+        verify(trainingRepository, never()).delete(any());
+    }
+
+    @Test
+    void deleteExerciseTraining_trainingNotFound() {
+        when(trainingRepository.findById(1)).thenReturn(Optional.empty());
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.deleteExerciseTraining(1, 2));
+        assertEquals("Training not found", e.getMessage());
+        verify(trainingExerciseRepository, never()).deleteByTrainingIdAndExerciseId(anyInt(), anyInt());
+    }
+
+    @Test
+    void deleteExerciseTraining_exerciseNotFound() {
+        Training training = new Training();
+        training.setId(1);
+        when(trainingRepository.findById(1)).thenReturn(Optional.of(training));
+        when(exerciseRepository.findById(2)).thenReturn(Optional.empty());
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> service.deleteExerciseTraining(1, 2));
+        assertEquals("Exercise not found", e.getMessage());
+        verify(trainingExerciseRepository, never()).deleteByTrainingIdAndExerciseId(anyInt(), anyInt());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure TrainingExerciseServiceImpl removes only association between training and exercise
- add repository method to delete by training and exercise IDs
- cover new behavior with TrainingExerciseServiceImpl unit tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688a201341108327b88324babe3a5889